### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 sudo: required
 before_install:
-- curl https://raw.githubusercontent.com/scala-native/scala-native/21539aa97947f7/bin/travis_setup.sh | bash -x
+- curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
 - wget https://raw.githubusercontent.com/paulp/sbt-extras/3c8fcadc3376edfd8e4b08b35f174935bf97bbac/sbt && chmod +x ./sbt
 script:
 - ./sbt exampleJVM/test exampleJS/test exampleNative/test exampleNative/nativeLink


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.